### PR TITLE
Decades later temp files for 1.1 update 080524

### DIFF
--- a/dl/src/blue_stars_compat.cpp
+++ b/dl/src/blue_stars_compat.cpp
@@ -4,6 +4,8 @@
 #include <sm64.h>
 extern "C"
 {
+    #include <level_commands.h>
+    #include <game/area.h>
     #include <game/interaction.h>
     #include <game/ingame_menu.h>
     #include <game/game.h>
@@ -249,11 +251,28 @@ s32 starNoExitSelect(struct MarioState *m, u32 interactType, struct Object *o)
     s16 bparam4 = o->OBJECT_FIELD_U32(0x40) & 0xff;
     bool blueStar = 0 != bparam4;
 
-    // all gold stars are noExit=true
-    if (!blueStar)
-        return 0;
+    if (!blueStar) // all yellow stars
+    {
+        if ((gCurrLevelNum == LEVEL_WMOTR && gCurrAreaIndex < 6) || (gCurrLevelNum == LEVEL_CASTLE_COURTYARD && gCurrAreaIndex == 3))
+            return 1;
+        else
+            return 0;
+    }
 
-    // add conditions here, currently all blues are nonstop + warp to safe pos
+    if ((gCurrLevelNum == LEVEL_COTMC) || (gCurrLevelNum == LEVEL_VCUTM) || (gCurrLevelNum == LEVEL_ENDING)
+    || (gCurrLevelNum == LEVEL_WMOTR)
+    || (gCurrLevelNum == LEVEL_WF  && gCurrAreaIndex == 3)
+    || (gCurrLevelNum == LEVEL_LLL  && gCurrAreaIndex == 2)
+    || (gCurrLevelNum == LEVEL_SSL  && gCurrAreaIndex == 4)
+    || (gCurrLevelNum == LEVEL_SL  && gCurrAreaIndex == 3)
+    || (gCurrLevelNum == LEVEL_TTC  && gCurrAreaIndex == 2)
+    || (gCurrLevelNum == LEVEL_BITDW) || (gCurrLevelNum == LEVEL_BITFS && gCurrAreaIndex == 1) || (gCurrLevelNum == LEVEL_BITS)
+    || (gCurrLevelNum == LEVEL_TOTWC))
+        return 0;
+    
+    if (gCurrLevelNum == LEVEL_BITFS && gCurrAreaIndex == 2)
+        return 1; 
+
     gNonStopState = NonStopState::WARP_TO_SAFE_POS;
     return 1; // no exit==true
 }

--- a/dl/src/star_radar.cpp
+++ b/dl/src/star_radar.cpp
@@ -149,7 +149,6 @@ void renderStarRadar()
     Texture* yellowTexture = (Texture*) 0x0407CA00;
     Texture* redTexture = (Texture*) 0x0407EE00;
     Texture* blueTexture = (Texture*) 0x0407A600;
-    int BaseOffset = 0;
 
     if (gCurrLevelNum != LEVEL_BOWSER_1 && gCurrLevelNum != LEVEL_BOWSER_2 && gCurrLevelNum != LEVEL_BOWSER_3)
     {
@@ -237,21 +236,23 @@ void renderStarRadar()
             return;
         }
 
+        float BaseOffset = 0;
+
         if ((starMask == 0b1111111) || (starMask == (1 << 7) - 1))
         {
             BaseOffset = 0;
         }
         else if (starMask == 0b111111)
         {
-            BaseOffset = 1;
+            BaseOffset = 0.75;
         }
         else if (starMask == 0b11111)
         {
-            BaseOffset = 2;
+            BaseOffset = 1;
         }
         else if (gCurrLevelNum == LEVEL_TOTWC && gCurrAreaIndex < 4)
         {
-            BaseOffset = 5;
+            BaseOffset = 2.5;
         }
         else
         {
@@ -334,7 +335,7 @@ void renderStarRadar()
                     }
                     else
                     {
-                        render_hud_tex_lut(104 + 16 * (off + BaseOffset / 2), 208, tex);
+                        render_hud_tex_lut(104 + 16 * (off + BaseOffset), 208, tex);
                     }
                 }
                 off++;

--- a/dl/src/stardisplay.cpp
+++ b/dl/src/stardisplay.cpp
@@ -3,6 +3,8 @@
 #include "types.h"
 extern "C" 
 {
+    #include <level_commands.h>
+    #include <game/area.h>
     #include "game/game.h"
     #include "game/level_update.h"
     #include "game/ingame_menu.h"
@@ -21,6 +23,22 @@ extern "C"
 
 static s8 menuPicked = 1;
 
+int SetFloor()
+{
+    if ((gMarioStates->numStars == 0)
+    || (gCurrLevelNum == LEVEL_CASTLE_COURTYARD && gCurrAreaIndex > 1))
+        return 1;
+    else if ((gCurrLevelNum == LEVEL_CASTLE && gCurrAreaIndex == 1))
+        return 2;
+    else if ((gCurrLevelNum == LEVEL_CASTLE_GROUNDS && gCurrAreaIndex == 1)
+    || (gCurrLevelNum == LEVEL_CASTLE && gCurrAreaIndex == 2))
+        return 3;
+    else if ((gCurrLevelNum == LEVEL_CASTLE_COURTYARD && gCurrAreaIndex == 1))
+        return 4;
+    else
+        return 5;
+}
+
 static void SPrintInt3(u8* str, int val)
 {
     int_to_str(val, str);
@@ -30,17 +48,11 @@ static void SPrintInt3(u8* str, int val)
 int Offsetter(int val)
 {
     if (val >= 100)
-    {
         return 0;
-    }
     else if (val >= 10)
-    {
         return 7;
-    }
     else
-    {
         return 14;
-    }
 }
 
 void StarDisplay()
@@ -58,6 +70,16 @@ void StarDisplay()
     {
         A_Press = !A_Press;
     }
+
+    static bool initialized;
+    if (!initialized)
+    {
+        menuPicked = SetFloor();
+        initialized = true;
+    }
+
+    if ((gPlayer1Controller->buttonPressed & START_BUTTON)||(gPlayer1Controller->buttonPressed & A_BUTTON))
+        initialized = false;
 
     if (gMarioStates->numStars == 0)
     {
@@ -122,8 +144,8 @@ void StarDisplay()
     }
 
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
-    static const u8 Version[] = { 0x39, 0x01, 0x3F, 0x00, 0x3F, 0x05, 0xFF };
-    print_generic_string(280, 220, Version);
+    static const u8 Version[] = { 0x39, 0x01, 0x3F, 0x01, 0xFF };
+    print_generic_string(294, 220, Version);
 
     if (gMarioStates->numStars < 333)
     {


### PR DESCRIPTION
- Added some conditions (probably still subject to change)
- In-game star display will now default to the floor you are on rather than 2nd floor being the default
- Fixed the position of the the star radar when it's only 6 stars (wasn't really centered before)